### PR TITLE
specifying version of pika.  New version breaks the tool (1.0.1)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pika
+pika==0.13.1
 logger


### PR DESCRIPTION
newest version of pika was causing a type error
```
[16/May/2019 14:40:51] INFO - Created channel=1
[16/May/2019 14:40:51] ERROR - Consumer Error that does not look like connection failure! See the traceback below.
[16/May/2019 14:40:51] ERROR - Traceback (most recent call last):
  File "/Users/tramah/development/repos/samsnguy/pika_bootstrap/stream_consumer.py", line 30, in run
    self.start_consuming()
  File "/pika_bootstrap/stream_consumer.py", line 55, in start_consuming
    self._channel.basic_consume(self.on_message, self._queue_name)
  File "/pika_bootstrap/env/lib/python2.7/site-packages/pika/adapters/blocking_connection.py", line 1617, in basic_consume
    validators.require_string(queue, 'queue')
  File "/pika_bootstrap/env/lib/python2.7/site-packages/pika/validators.py", line 17, in require_string
    value,
TypeError: queue must be a str or unicode str, but got <bound method StreamConsumer.on_message of <stream_consumer.StreamConsumer object at 0x105659390>>
```