### PR TITLE
Fix issue with basic_consume paremter order between v0.13.1 and v1.0.0+

### DIFF
--- a/stream_consumer.py
+++ b/stream_consumer.py
@@ -52,7 +52,7 @@ class StreamConsumer(object):
     def start_consuming(self):
         self._channel = self._connection.channel()
         self._channel.queue_declare(self._queue_name, passive=True)
-        self._channel.basic_consume(self.on_message, self._queue_name)
+        self._channel.basic_consume(queue=self._queue_name, on_message_callback=self.on_message)
         logger.info('Connected. Starting to consume.')
         self._channel.start_consuming()
 


### PR DESCRIPTION
In version 0.13.1 the adapters/blocking_connection.py defined basic_consume with parameters consumer_callback and queue in that order. In version 1.0.0 they changed the parameters to queue and on_message_callback with this new order.

This fix uses named parameters to be compatible with version 1.0.0+  but breaks compatibility with version 0.13.1 or earlier
